### PR TITLE
Add Google Apps Script for contact form submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-"# lawns-llc" 
+# lawns-llc
+
+This repository contains the static website for **L.A.W.N.S. LLC**. The site is deployed to an S3 bucket using AWS SAM. The contact form on the landing page posts to a Google Apps Script which writes submissions to a Google Sheet.
+
+The Google Apps Script code used by the form can be found in `google-apps-script.js`. Deploy this script as a Web App and use the generated URL in `index.html`.

--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -1,0 +1,40 @@
+/**
+ * This function handles incoming POST requests (URL-encoded form data).
+ * It reads each field from e.parameter and appends a row in the Sheet.
+ */
+function doPost(e) {
+  // e.parameter contains each form field (because we'll send as URL-encoded),
+  // e.g. e.parameter.name, e.parameter.email, etc.
+  var params = e.parameter;
+
+  // Get the active sheet (the one you opened):
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+
+  // Build a new row: [Timestamp, Name, Email, Phone, Address, Services]
+  var newRow = [
+    new Date(),
+    params.name    || "",
+    params.email   || "",
+    params.phone   || "",
+    params.address || "",
+    params.services|| ""
+  ];
+
+  // Append that row to the bottom of the sheet:
+  sheet.appendRow(newRow);
+
+  // Return a minimal text response (the client uses "no-cors" so the response will be opaque).
+  return ContentService
+    .createTextOutput("OK")
+    .setMimeType(ContentService.MimeType.TEXT);
+}
+
+/**
+ * If a GET request ever arrives (unlikely, since our form only does POST),
+ * this returns a harmless "OK" so the script doesn't throw a 405.
+ */
+function doGet(e) {
+  return ContentService
+    .createTextOutput("OK")
+    .setMimeType(ContentService.MimeType.TEXT);
+}


### PR DESCRIPTION
## Summary
- add a Google Apps Script to handle POST/GET requests from the contact form
- document script usage in the README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68421e28a42c8321891f9d2696e7c09a