### PR TITLE
Add service pages with navigation

### DIFF
--- a/area-served.html
+++ b/area-served.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Property Management | L.A.W.N.S. LLC</title>
+  <title>Area Served | L.A.W.N.S. LLC</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -22,26 +22,15 @@
     <div class="hero-overlay"></div>
     <div class="hero-content">
       <img src="assets/landingpage/transparent-logo.png" alt="LAWNS LLC Logo" />
-      <h1>Property Management</h1>
-      <p>Between closing mowing and ongoing upkeep</p>
+      <h1>Area Served</h1>
+      <p>Professional lawncare throughout Iowa</p>
       <a href="index.html#contactForm" class="cta-btn">Request Service</a>
     </div>
   </header>
-
-  <div class="service-grid">
-    <section class="property-management">
-      <h2>Between Closing Mowing</h2>
-      <p>Keep your vacant property presentable while it awaits new owners. We offer scheduled mowing, trimming, and cleanup so the lawn stays neat throughout the transition.</p>
-      <p>Need more than mowing? We can remove leaves, clear debris, and perform other maintenance for rentals and second homes.</p>
-    </section>
-    <section class="additional-services">
-      <h2>Additional Services</h2>
-      <ul>
-        <li><a href="services/hauling-dumping.html">Hauling &amp; Dumping</a></li>
-      </ul>
-    </section>
+  <div class="property-management">
+    <h2>Serving Central Iowa</h2>
+    <p>We provide lawncare services in Ames, Des Moines, and the surrounding communities.</p>
   </div>
-
   <footer>
     &copy; 2025 L.A.W.N.S. LLC • All rights reserved
   </footer>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,15 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="services/mowing.html">Mowing</a></li>
+      <li><a href="services/aeration.html">Aeration</a></li>
+      <li><a href="services/hauling-dumping.html">Hauling &amp; Dumping</a></li>
+      <li><a href="property-management.html">Property Management</a></li>
+    </ul>
+  </nav>
 
   <header class="hero">
     <div class="hero-overlay"></div>
@@ -21,8 +30,8 @@
   <section class="acronym">
     <h2>Our Services</h2>
     <ul>
-      <li><strong>L</strong>awncare</li>
-      <li><strong>A</strong>eration</li>
+      <li><strong>L</strong><a href="services/mowing.html">awncare</a></li>
+      <li><strong>A</strong><a href="services/aeration.html">eration</a></li>
       <li><strong>W</strong>eed Trimming</li>
       <li><strong>N</strong>utrients</li>
       <li><strong>S</strong>eeding & Snow Removal</li>
@@ -34,7 +43,7 @@
   <section class="additional-services">
     <h2>Additional Services</h2>
     <ul>
-      <li>Hauling & Dumping</li>
+      <li><a href="services/hauling-dumping.html">Hauling &amp; Dumping</a></li>
     </ul>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -8,12 +8,14 @@
 </head>
 <body>
   <nav class="main-nav">
-    <ul>
+    <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+    <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
+      <li><a href="area-served.html">Area Served</a></li>
+      <li><a href="property-management.html">Property Management</a></li>
       <li><a href="services/mowing.html">Mowing</a></li>
       <li><a href="services/aeration.html">Aeration</a></li>
       <li><a href="services/hauling-dumping.html">Hauling &amp; Dumping</a></li>
-      <li><a href="property-management.html">Property Management</a></li>
     </ul>
   </nav>
 
@@ -98,10 +100,17 @@
   </footer>
 
   <script>
-    document.getElementById("contactForm").onsubmit = function (e) {
+    const navBtn = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    navBtn.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+    });
+
+    const contactForm = document.getElementById('contactForm');
+    if (contactForm) contactForm.onsubmit = function (e) {
       e.preventDefault();
       const form = e.target;
-      const responseEl = document.getElementById("responseMsg");
+      const responseEl = document.getElementById('responseMsg');
 
       // Build a JS object from the form’s inputs
       const formData = new FormData(form);

--- a/property-management.html
+++ b/property-management.html
@@ -7,6 +7,15 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li><a href="services/mowing.html">Mowing</a></li>
+      <li><a href="services/aeration.html">Aeration</a></li>
+      <li><a href="services/hauling-dumping.html">Hauling &amp; Dumping</a></li>
+      <li><a href="property-management.html">Property Management</a></li>
+    </ul>
+  </nav>
   <header class="hero">
     <div class="hero-overlay"></div>
     <div class="hero-content">
@@ -26,7 +35,7 @@
     <section class="additional-services">
       <h2>Additional Services</h2>
       <ul>
-        <li>Hauling &amp; Dumping</li>
+        <li><a href="services/hauling-dumping.html">Hauling &amp; Dumping</a></li>
       </ul>
     </section>
   </div>

--- a/services/aeration.html
+++ b/services/aeration.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Aeration Services | L.A.W.N.S. LLC</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="../index.html">Home</a></li>
+      <li><a href="mowing.html">Mowing</a></li>
+      <li><a href="aeration.html">Aeration</a></li>
+      <li><a href="hauling-dumping.html">Hauling &amp; Dumping</a></li>
+      <li><a href="../property-management.html">Property Management</a></li>
+    </ul>
+  </nav>
+  <header class="hero">
+    <div class="hero-overlay"></div>
+    <div class="hero-content">
+      <img src="../assets/landingpage/transparent-logo.png" alt="LAWNS LLC Logo" />
+      <h1>Aeration Services</h1>
+      <p>Improve soil health and grass growth</p>
+      <a href="../index.html#contactForm" class="cta-btn">Request Service</a>
+    </div>
+  </header>
+
+  <div class="service-grid">
+    <section class="property-management">
+      <h2>Core Aeration</h2>
+      <p>Aeration loosens compacted soil, allowing water and nutrients to reach the roots. Your lawn will be thicker and healthier.</p>
+      <img src="../assets/landingpage/sidewalk-cleanup.jpg" alt="Lawn aeration" />
+    </section>
+  </div>
+
+  <footer>
+    &copy; 2025 L.A.W.N.S. LLC • All rights reserved
+  </footer>
+</body>
+</html>

--- a/services/aeration.html
+++ b/services/aeration.html
@@ -8,12 +8,14 @@
 </head>
 <body>
   <nav class="main-nav">
-    <ul>
+    <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+    <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
+      <li><a href="../area-served.html">Area Served</a></li>
+      <li><a href="../property-management.html">Property Management</a></li>
       <li><a href="mowing.html">Mowing</a></li>
       <li><a href="aeration.html">Aeration</a></li>
       <li><a href="hauling-dumping.html">Hauling &amp; Dumping</a></li>
-      <li><a href="../property-management.html">Property Management</a></li>
     </ul>
   </nav>
   <header class="hero">
@@ -37,5 +39,12 @@
   <footer>
     &copy; 2025 L.A.W.N.S. LLC • All rights reserved
   </footer>
+  <script>
+    const navBtn = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    navBtn.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+    });
+  </script>
 </body>
 </html>

--- a/services/hauling-dumping.html
+++ b/services/hauling-dumping.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Hauling &amp; Dumping | L.A.W.N.S. LLC</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="../index.html">Home</a></li>
+      <li><a href="mowing.html">Mowing</a></li>
+      <li><a href="aeration.html">Aeration</a></li>
+      <li><a href="hauling-dumping.html">Hauling &amp; Dumping</a></li>
+      <li><a href="../property-management.html">Property Management</a></li>
+    </ul>
+  </nav>
+  <header class="hero">
+    <div class="hero-overlay"></div>
+    <div class="hero-content">
+      <img src="../assets/landingpage/transparent-logo.png" alt="LAWNS LLC Logo" />
+      <h1>Hauling &amp; Dumping</h1>
+      <p>Debris removal and material hauling services</p>
+      <a href="../index.html#contactForm" class="cta-btn">Request Service</a>
+    </div>
+  </header>
+
+  <div class="service-grid">
+    <section class="property-management">
+      <h2>Cleanups &amp; Hauling</h2>
+      <p>Whether you need brush, junk, or yard waste removed, we have the equipment to haul it away quickly and responsibly.</p>
+      <img src="../assets/landingpage/wide-driveway-cleanup.jpg" alt="Trailer ready for hauling" />
+    </section>
+  </div>
+
+  <footer>
+    &copy; 2025 L.A.W.N.S. LLC • All rights reserved
+  </footer>
+</body>
+</html>

--- a/services/hauling-dumping.html
+++ b/services/hauling-dumping.html
@@ -8,12 +8,14 @@
 </head>
 <body>
   <nav class="main-nav">
-    <ul>
+    <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+    <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
+      <li><a href="../area-served.html">Area Served</a></li>
+      <li><a href="../property-management.html">Property Management</a></li>
       <li><a href="mowing.html">Mowing</a></li>
       <li><a href="aeration.html">Aeration</a></li>
       <li><a href="hauling-dumping.html">Hauling &amp; Dumping</a></li>
-      <li><a href="../property-management.html">Property Management</a></li>
     </ul>
   </nav>
   <header class="hero">
@@ -37,5 +39,12 @@
   <footer>
     &copy; 2025 L.A.W.N.S. LLC • All rights reserved
   </footer>
+  <script>
+    const navBtn = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    navBtn.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+    });
+  </script>
 </body>
 </html>

--- a/services/mowing.html
+++ b/services/mowing.html
@@ -8,12 +8,14 @@
 </head>
 <body>
   <nav class="main-nav">
-    <ul>
+    <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+    <ul class="nav-links">
       <li><a href="../index.html">Home</a></li>
+      <li><a href="../area-served.html">Area Served</a></li>
+      <li><a href="../property-management.html">Property Management</a></li>
       <li><a href="mowing.html">Mowing</a></li>
       <li><a href="aeration.html">Aeration</a></li>
       <li><a href="hauling-dumping.html">Hauling &amp; Dumping</a></li>
-      <li><a href="../property-management.html">Property Management</a></li>
     </ul>
   </nav>
   <header class="hero">
@@ -37,5 +39,12 @@
   <footer>
     &copy; 2025 L.A.W.N.S. LLC • All rights reserved
   </footer>
+  <script>
+    const navBtn = document.querySelector('.nav-toggle');
+    const navLinks = document.querySelector('.nav-links');
+    navBtn.addEventListener('click', () => {
+      navLinks.classList.toggle('open');
+    });
+  </script>
 </body>
 </html>

--- a/services/mowing.html
+++ b/services/mowing.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Mowing Services | L.A.W.N.S. LLC</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+<body>
+  <nav class="main-nav">
+    <ul>
+      <li><a href="../index.html">Home</a></li>
+      <li><a href="mowing.html">Mowing</a></li>
+      <li><a href="aeration.html">Aeration</a></li>
+      <li><a href="hauling-dumping.html">Hauling &amp; Dumping</a></li>
+      <li><a href="../property-management.html">Property Management</a></li>
+    </ul>
+  </nav>
+  <header class="hero">
+    <div class="hero-overlay"></div>
+    <div class="hero-content">
+      <img src="../assets/landingpage/transparent-logo.png" alt="LAWNS LLC Logo" />
+      <h1>Mowing Services</h1>
+      <p>Keep your lawn pristine with regular mowing and trimming</p>
+      <a href="../index.html#contactForm" class="cta-btn">Request Service</a>
+    </div>
+  </header>
+
+  <div class="service-grid">
+    <section class="property-management">
+      <h2>Professional Lawncare</h2>
+      <p>Our team provides meticulous mowing, trimming, and edging to maintain a beautiful, healthy lawn all season long.</p>
+      <img src="../assets/landingpage/background.jpg" alt="Freshly mowed lawn" />
+    </section>
+  </div>
+
+  <footer>
+    &copy; 2025 L.A.W.N.S. LLC • All rights reserved
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@ body {
   z-index: 10;
   padding: 0.5rem;
 }
-.main-nav ul {
+.main-nav .nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -29,6 +29,13 @@ body {
 }
 .main-nav a:hover {
   text-decoration: underline;
+}
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
 }
 .hero {
   position: relative;
@@ -209,4 +216,20 @@ footer {
   max-height: 300px;
   border-radius: 8px;
   object-fit: cover;
+}
+
+@media (max-width: 600px) {
+  .nav-toggle {
+    display: block;
+  }
+  .main-nav .nav-links {
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+  .main-nav .nav-links.open {
+    display: flex;
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,31 @@ body {
   background-color: #f4f8f4;
   color: #333;
 }
+
+.main-nav {
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 0.5rem;
+}
+.main-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+.main-nav a {
+  text-decoration: none;
+  color: #2e7d32;
+  font-weight: bold;
+}
+.main-nav a:hover {
+  text-decoration: underline;
+}
 .hero {
   position: relative;
   background: url('assets/landingpage/background.jpg') center/cover no-repeat;


### PR DESCRIPTION
## Summary
- create new `services/` folder with individual pages for mowing, aeration and hauling
- introduce a sticky navigation menu across the site
- link new pages from the service list and property management page
- style the navigation menu in `styles.css`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68422742a6c0832192c39e0a4fd30d92